### PR TITLE
feat(auth): add email verification endpoint with OTP validation

### DIFF
--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -24,6 +24,18 @@ export class UserRepository {
 		return this.mapRowToUser(result.rows[0]);
 	}
 
+	static async findByOptCode(optCode: string): Promise<User | undefined> {
+		const sql =
+			"SELECT * FROM users WHERE opt_code = $1 AND opt_code_expires_at > CURRENT_TIMESTAMP";
+		const result = await query(sql, [optCode]);
+
+		if (result.rows.length === 0) {
+			return undefined;
+		}
+
+		return this.mapRowToUser(result.rows[0]);
+	}
+
 	static async findById(id: string): Promise<User | null> {
 		const sql = "SELECT * FROM users WHERE id = $1";
 		const result = await query(sql, [id]);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -25,6 +25,10 @@ const refreshTokenSchema = z.object({
 	refreshToken: z.string().min(1, "Refresh token is required"),
 });
 
+const verifyEmailSchema = z.object({
+	optCode: z.string().min(1, "OTP is required"),
+});
+
 const forgotPasswordSchema = z.object({
 	email: z.string().email("Invalid email format"),
 });
@@ -316,4 +320,5 @@ export {
 	trackEventSchema,
 	vendorAnalyticsSchema,
 	dateRangeSchema,
+	verifyEmailSchema,
 };


### PR DESCRIPTION
Implement email verification flow by adding:
- verifyEmailSchema for OTP validation
- findByOptCode method in UserRepository
- /verify-email endpoint to handle verification requests