### PR TITLE
feat(auth): implement email verification and password reset with OTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ docker-compose -f docker-compose.prod.yml up -d
 ### Authentication Endpoints
 - `POST /api/auth/register` - User registration
 - `POST /api/auth/login` - User login
+- `POST /api/auth/verify-email` - Verify email
 - `POST /api/auth/refresh` - Refresh tokens
 - `POST /api/auth/logout` - User logout
 - `GET /api/auth/me` - Get current user

--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -135,11 +135,12 @@ export class UserRepository {
 		}
 
 		const sql = `
-      UPDATE users 
-      SET ${fields.join(", ")}
-      WHERE id = $${++paramCount}
-      RETURNING *
-    `;
+			UPDATE users 
+			SET ${fields.join(", ")}
+			WHERE id = $${++paramCount}
+			RETURNING *
+			`;
+
 		values.push(id);
 
 		const result = await query(sql, values);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -368,7 +368,7 @@ auth.post(
 			const { optCode, password } = c.req.valid("json");
 			const user = await UserRepository.findByOptCode(optCode);
 			if (!user) {
-				throw createError.badRequest("Invalid or expired reset token");
+				throw createError.badRequest("Invalid or expired optCode");
 			}
 
 			const hashPassword = await Bun.password.hash(password);
@@ -379,14 +379,14 @@ auth.post(
 				optCodeExpiresAt: undefined,
 			});
 
-			logger.info("Password reset successfully", { userId: user.id });
+			logger.info("Password reset successfully");
 
 			return c.json({
 				message: "Password reset successful",
 			});
 		} catch (error) {
 			logger.error("Password reset failed", error as Error);
-			throw createError.badRequest("Invalid or expired reset token");
+			throw createError.badRequest("Invalid or expired optCode");
 		}
 	},
 );

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -13,7 +13,7 @@ import {
 	sendDeliveryConfirmationEmail,
 	sendOrderConfirmationEmail,
 	sendOtpEmail,
-	sendPasswordResetEmail,
+	sendPasswordResetTemplate,
 	sendPaymentConfirmationEmail,
 	sendShippingConfirmationEmail,
 	welcomeTemplate,
@@ -56,11 +56,13 @@ export class EmailService {
 		return this.sendEmail(email);
 	}
 
-	static async sendPasswordResetEmail(
-		user: { firstName: string; lastName: string; email: string },
-		resetLink: string,
-	) {
-		const email = await sendPasswordResetEmail(user, resetLink);
+	static async sendPasswordResetEmail(user: {
+		firstName: string;
+		lastName: string;
+		email: string;
+		optCode: string;
+	}) {
+		const email = await sendPasswordResetTemplate(user);
 		return this.sendEmail(email);
 	}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,8 @@ export interface UpdateUserData {
 	avatarUrl?: string;
 	isActive?: boolean;
 	emailVerified?: boolean;
+	optCode?: string;
+	optCodeExpiresAt?: Date;
 }
 
 export interface Cart {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,8 +33,9 @@ export interface UpdateUserData {
 	avatarUrl?: string;
 	isActive?: boolean;
 	emailVerified?: boolean;
-	optCode?: string;
-	optCodeExpiresAt?: Date;
+	optCode?: string | undefined;
+	optCodeExpiresAt?: Date | undefined;
+	passwordHash?: string | undefined;
 }
 
 export interface Cart {

--- a/src/utils/email/templates/index.ts
+++ b/src/utils/email/templates/index.ts
@@ -56,21 +56,23 @@ If you did not register with Live Ecommerce, please ignore this email.
 `,
 });
 
-export const sendPasswordResetEmail = (
-	user: { firstName: string; lastName: string; email: string },
-	resetOTP: string,
-) => ({
+export const sendPasswordResetTemplate = (user: {
+	firstName: string;
+	lastName: string;
+	email: string;
+	optCode: string;
+}) => ({
 	to: user.email,
 	subject: "Password Reset Request",
 	html: `
     <p>Hello ${user.firstName} ${user.lastName},</p>
     <p>We received a request to reset your password. Please use the following OTP to reset your password:</p>
-    <p><strong>${resetOTP}</strong></p>
+    <p><strong>${user.optCode}</strong></p>
     <p>If you did not request a password reset, please ignore this email.</p>
   `,
 	text: `Hello ${user.firstName} ${user.lastName},
 We received a request to reset your password. Please use the following OTP to reset your password:
-${resetOTP}
+${user.optCode}
 If you did not request a password reset, please ignore this email.
 
 `,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -34,7 +34,7 @@ const forgotPasswordSchema = z.object({
 });
 
 const resetPasswordSchema = z.object({
-	token: z.string().min(1, "Reset token is required"),
+	optCode: z.string().min(1, "OTP is required"),
 	password: z.string().min(8, "Password must be at least 8 characters"),
 });
 


### PR DESCRIPTION
- Add OTP code and expiration fields to UpdateUserData interface
- Implement password reset flow with OTP generation and email sending
- Update email template to use OTP code from user object
- Add new verify-email endpoint to README
- Replace direct reset token with OTP in password reset functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset now uses a 6-digit OTP code sent via email, replacing the previous token-based method.

* **Improvements**
  * Password reset and email templates updated for OTP-based flow.
  * Enhanced logging for password reset events.
  * User info endpoint now returns vendor field as undefined when not present.

* **Documentation**
  * Updated README to include a new email verification endpoint and revised authentication flow details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->